### PR TITLE
Prevent repeating entries in _neighbors and explain how units and peers are encoded

### DIFF
--- a/sudoku.en.cc
+++ b/sudoku.en.cc
@@ -71,15 +71,15 @@ void Sudoku::write(ostream& o) const {
 }
 
 /**
- * _group[i] for i in {0 .. 8} = horizontal units (i-th row)
- * _group[j] for j in {9 .. 17} = vertical units (j-th column)
- * _group[k] for k in {18 .. 26} = square unit counted left to right
- *                                 top to bottom
- * _group_of[i] = unit indices of box i in _group.
+ * for i in {0 .. 8} _group[i] = horizontal units ((i)th row)
+ * for j in {9 .. 17} _group[j] = vertical units ((j - 9)th column)
+ * for k in {18 .. 26} _group[k] = square unit counted left to right
+ *                                 top to bottom ((k - 18)th square unit)
+ * _group_of[i] = unit indices in _group for i-th box.
  * Therefore, for all i in {0 .. 80},  _group_of[i].size() = 3
  *            i.e. each box belongs to exactly 3 units.
  * 
- * _neighbors[i] for i in {0 .. 80} = peers of i-th box
+ * for i in {0 .. 80} _neighbors[i] = peers of i-th box
  */
 vector< vector<int> > 
 Sudoku::_group(27), Sudoku::_neighbors(81), Sudoku::_groups_of(81);

--- a/sudoku.en.cc
+++ b/sudoku.en.cc
@@ -88,7 +88,8 @@ void Sudoku::init() {
       for (int x = 0; x < _groups_of[k].size(); x++) {
          for (int j = 0; j < 9; j++) {
             int k2 = _group[_groups_of[k][x]][j];
-            if (k2 != k) _neighbors[k].push_back(k2);
+            if (k2 != k && !(x == 2 && (abs(k2 - k) < 3 || abs(k2 - k) % 3 == 0))) 
+               _neighbors[k].push_back(k2);
          }
       }
    }

--- a/sudoku.en.cc
+++ b/sudoku.en.cc
@@ -70,6 +70,17 @@ void Sudoku::write(ostream& o) const {
    }
 }
 
+/**
+ * _group[i] for i in {0 .. 8} = horizontal units (i-th row)
+ * _group[j] for j in {9 .. 17} = vertical units (j-th column)
+ * _group[k] for k in {18 .. 26} = square unit counted left to right
+ *                                 top to bottom
+ * _group_of[i] = unit indices of box i in _group.
+ * Therefore, for all i in {0 .. 80},  _group_of[i].size() = 3
+ *            i.e. each box belongs to exactly 3 units.
+ * 
+ * _neighbors[i] for i in {0 .. 80} = peers of i-th box
+ */
 vector< vector<int> > 
 Sudoku::_group(27), Sudoku::_neighbors(81), Sudoku::_groups_of(81);
 

--- a/sudoku.en.cc
+++ b/sudoku.en.cc
@@ -74,12 +74,12 @@ void Sudoku::write(ostream& o) const {
  * for i in {0 .. 8} _group[i] = horizontal units ((i)th row)
  * for j in {9 .. 17} _group[j] = vertical units ((j - 9)th column)
  * for k in {18 .. 26} _group[k] = square unit counted left to right
- *                                 top to bottom ((k - 18)th square unit)
- * _group_of[i] = unit indices in _group for i-th box.
+ *                                 top to bottom ((k - 18)th box)
+ * _group_of[i] = unit indices in _group for i-th square.
  * Therefore, for all i in {0 .. 80},  _group_of[i].size() = 3
- *            i.e. each box belongs to exactly 3 units.
+ *            i.e. each square belongs to exactly 3 units.
  * 
- * for i in {0 .. 80} _neighbors[i] = peers of i-th box
+ * for i in {0 .. 80} _neighbors[i] = peers of i-th square
  */
 vector< vector<int> > 
 Sudoku::_group(27), Sudoku::_neighbors(81), Sudoku::_groups_of(81);


### PR DESCRIPTION
I landed on this repo via Peter Norvig's [webpage](https://norvig.com/sudoku.html). Some of the terminology used on his page is different than in your implementation. The comments make it easier to understand the contents of the vectors that store the units of a box - `_group` - and the positions of the units in that vector for a given box - `_group_of`. `_neighbors` contextually refers to `peers`.

Moreover, `_neighbors` contained unnecessary repeating entries in the implementation. Now, `_neighbors` resembles the set of peers.